### PR TITLE
Feature/route browsing

### DIFF
--- a/server/road_safety/urls.py
+++ b/server/road_safety/urls.py
@@ -21,6 +21,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('rs_core.urls')),
     path('', TemplateView.as_view(template_name='home.html'), name='home'),
-    path('browse/annotation', TemplateView.as_view(template_name='home.html'), name='home'),
-    path('browse/route', TemplateView.as_view(template_name='home.html'), name='home')
+    re_path(r'routes(?:.*)/?', TemplateView.as_view(template_name='home.html'), name='home'),
+    #re_path(r'^(?:.*)/?$', TemplateView.as_view(template_name='home.html'), name='home'),
 ]

--- a/server/road_safety/urls.py
+++ b/server/road_safety/urls.py
@@ -22,5 +22,4 @@ urlpatterns = [
     path('', include('rs_core.urls')),
     path('', TemplateView.as_view(template_name='home.html'), name='home'),
     re_path(r'routes(?:.*)/?', TemplateView.as_view(template_name='home.html'), name='home'),
-    #re_path(r'^(?:.*)/?$', TemplateView.as_view(template_name='home.html'), name='home'),
 ]


### PR DESCRIPTION
for the client, i want to add `/routes` catch-all to this `urls.py`. we need it to catch routes like the following:

- `/routes`
- `/routes/30600024060/`
- `/routes/routes/30600024060/102`

i've also removed the `browse/annotation` route, as we've removed the need for that one.