### PR TITLE
Fixed output file naming to be inclusive

### DIFF
--- a/segmentation_scripts/slurm_job_generator.py
+++ b/segmentation_scripts/slurm_job_generator.py
@@ -28,9 +28,9 @@ def main(args):
         file_string = f'''
         #!/bin/bash
     
-        #SBATCH --job-name=d{division}-{chunk_start}-{chunk_end}
-        #SBATCH --output=output.d{division}-{chunk_start}-{chunk_end}
-        #SBATCH --error=output_err.d{division}-{chunk_start}-{chunk_end}
+        #SBATCH --job-name=d{division}-{chunk_start}-{chunk_end - 1}
+        #SBATCH --output=output.d{division}-{chunk_start}-{chunk_end - 1}
+        #SBATCH --error=output_err.d{division}-{chunk_start}-{chunk_end - 1}
         #SBATCH -p gpu
         #SBATCH -c 16
         #SBATCH --mem-per-cpu=2048


### PR DESCRIPTION
Output file names have folder ranges, which were including the non-inclusive folder sent to the bash loop